### PR TITLE
Remove non-standard ports for the node-port

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: argo-chart
 description: A chart that deploys argo
-version: v0.3.2
+version: v0.3.3
 
 dependencies:
   - name: argo-cd

--- a/nidhogg/values.yaml
+++ b/nidhogg/values.yaml
@@ -30,5 +30,3 @@ argo-cd:
           name: grafana
     service: 
       type: NodePort
-      nodePortHttp: 31080
-      nodePortHttps: 31443


### PR DESCRIPTION
The non-default port values were added because we experienced conflicts. It turned out that Nidhogg was installed in the wrong namespace, which solved the problem and made the new ports unnecessary.