### PR TITLE
Bumped dependency versions and own versions

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: v1.0.0
+version: v1.0.1
 
 dependencies:
   - name: nidhogg
-    version: "v0.5.5"
+    version: "v1.0.0"
     repository: "https://distributed-technologies.github.io/helm-repository/"

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: yggdrasil
 description: A Helm chart for deploying services and applications
 type: application
-version: v1.0.0
+version: v1.0.1
 
 dependencies: 
   - name: lightvessel
-    version: "v0.1.6"
+    version: "v1.0.0"
     repository: "https://distributed-technologies.github.io/helm-repository/"


### PR DESCRIPTION
I have bumped the lightvessel and nidhogg dependencies up to their correct versions 1.0.0 and 1.0.0 and then bumped Yggdrasils version to 1.0.1 in both /nidhogg and /yggdrasil