### PR TITLE
Fix version check workflow. Breaks on PR from fork.

### DIFF
--- a/.github/workflows/check_helm_version.yaml
+++ b/.github/workflows/check_helm_version.yaml
@@ -26,7 +26,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Get helm chart version
         run: | 

--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: v1.0.4
+version: v1.0.6
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: yggdrasil
 description: A Helm chart for deploying services and applications
 type: application
-version: v1.0.4
+version: v1.0.6
 
 dependencies: 
   - name: lightvessel


### PR DESCRIPTION
The checkout tried to look in the original repo and not the forked one.
We now parse in the reference from the pull request, which points the where the changes happened.

This will make changes from a fork work as well. 