### PR TITLE
nidhogg: Bump version and dependency version

### DIFF
--- a/nidhogg/Chart.lock
+++ b/nidhogg/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nidhogg
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 1.0.10
-digest: sha256:ac50e06ca749cd60913b5669f331ff4f188ea58faf3ed757faefa429435a3f66
-generated: "2021-11-09T12:23:24.785282635+01:00"
+  version: 1.0.12
+digest: sha256:abe1a121d02b885ecc44e3cef799c3214adfc5489e1324a1f79006efa6ff8921
+generated: "2021-11-12T12:56:08.968351531+01:00"

--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   - name: nidhogg
-    version: 1.0.10
+    version: 1.0.12
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.1
+version: 2.0.2
 
 dependencies: 
   - name: lightvessel


### PR DESCRIPTION
Reverse chronological order (in [1]):
63c5364 ("nidhogg: Bump version")
0fe114f ("nidhogg: Ensure proxy and root certificate values aren't "reverted"")
dd8b9cc ("nidhogg: Improve readability by indenting {{ toYaml }}")
969de7e ("nidhogg: Bump argo-cd-proxy-chart dependency")
01703b3 ("nidhogg: Add lb-proxy as dependency")

[1] https://github.com/distributed-technologies/helm-charts/