### PR TITLE
nidhogg: Bump nidhogg dependency version and sync changes

### DIFF
--- a/nidhogg/Chart.lock
+++ b/nidhogg/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nidhogg
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 1.0.12
-digest: sha256:abe1a121d02b885ecc44e3cef799c3214adfc5489e1324a1f79006efa6ff8921
-generated: "2021-11-12T12:56:08.968351531+01:00"
+  version: 1.0.13
+digest: sha256:3c688827adace7b6a39ce53d2868a3713edbac8652f6eeea4614f8fce1442cb0
+generated: "2021-11-18T11:40:40.221678245+01:00"

--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.2
+version: 2.0.3
 
 dependencies:
   - name: nidhogg
-    version: 1.0.12
+    version: 1.0.13
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/nidhogg/values.yaml
+++ b/nidhogg/values.yaml
@@ -36,31 +36,6 @@ nidhogg:
       server: 
         replicas: 3
         config:
-          repositories: |
-            - type: helm
-              url: https://argoproj.github.io/argo-helm
-              name: argoproj
-            - type: helm
-              url: https://distributed-technologies.github.io/helm-repository/
-              name: dt-helmrepo
-            - type: helm
-              url: https://kubernetes.github.io/kube-state-metrics
-              name: metrics
-            - type: helm
-              url: https://prometheus-community.github.io/helm-charts
-              name: node-exporter
-            - type: helm
-              url: https://grafana.github.io/helm-charts
-              name: grafana
-            - type: helm
-              url: https://strimzi.io/charts/
-              name: strimzi-kafka-operator
-            - type: helm
-              url: https://confluentinc.github.io/cp-helm-charts/
-              name: cp-helm-charts
-            - type: helm
-              url: https://charts.rook.io/release
-              name: rook-release
           resource.customizations: |
             admissionregistration.k8s.io/MutatingWebhookConfiguration:
               ignoreDifferences: |

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.2
+version: 2.0.3
 
 dependencies: 
   - name: lightvessel


### PR DESCRIPTION
99e7c88 ("nidhogg: Remove chart repositories from Argo")
"They aren't needed as we packaging the dependencies and Argo fails
deploying if they can't be reached (ex: in a air-gapped environment)."