### PR TITLE
yggdrasil: Bump loadbalancer version

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.4
+version: 2.0.5
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.4
+version: 2.0.5
 
 dependencies: 
   - name: lightvessel

--- a/yggdrasil/services/loadbalancer/config.yaml
+++ b/yggdrasil/services/loadbalancer/config.yaml
@@ -9,6 +9,6 @@ apps:
   - name: loadbalancer
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.1.6
+      targetRevision: 0.1.7
       chart: loadbalancer
       valuesFile: "loadbalancer.yaml"


### PR DESCRIPTION
Reverse chronological order (in [1]):
ad870e6 ("Version bump")
97af317 ("Set image tags and remove main tag")

[1] https://github.com/distributed-technologies/helm-charts