### PR TITLE
Add a listener for Kafka brokers on port 9092

### DIFF
--- a/yggdrasil/services/kafka/kafka/kafka.yaml
+++ b/yggdrasil/services/kafka/kafka/kafka.yaml
@@ -1,5 +1,10 @@
 cluster:
   kafka: 
+    listeners:
+    - name: internal
+      port: 9092
+      type: internal
+      tls: false
     storage:
       size: 5Gi 
     {{- if .Values.storageClass }}


### PR DESCRIPTION
The internal listener is needed for our configuring of bootstrap servers for Kafka brokers.