### PR TITLE
add workflow running `ct lint` on charts

### DIFF
--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,12 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint.md
+# Configuration for the ct helm cart linting
+remote: origin
+target-branch: main
+chart-dirs:
+  - yggdrasil
+  - nidhogg
+chart-repos:
+  - helmcharts=https://distributed-technologies.github.io/helm-charts/
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: true

--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  document-end: disable
+  document-start: disable # No --- to start a file
+  empty-lines:
+    max: 1
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+name: Lint charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Setup chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
+


### PR DESCRIPTION
The lint workflow uses the ct lint tool as is in use in our helm-charts
mono-repo. The lintconf.yaml is taken from that repository.

This will probably let us remove the "check_helm_version" workflow, since the `ct lint` also checks for version increments. However, I have not tested this yet ([see](https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md)).