### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig see: https://EditorConfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{yml, yaml}]
+indent_size = 2


### PR DESCRIPTION
The .editorconfig helps with consistent styles. By having this we
will need less linting. See https://EditorConfig.org for details.

To enable it in the editor you might need to install a plugin.