### PR TITLE
Bumped Nidhogg version, pointed to newest Lightvessel version and added flag for circular dependency

### DIFF
--- a/nidhogg/Chart.lock
+++ b/nidhogg/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nidhogg
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 1.0.13
-digest: sha256:3c688827adace7b6a39ce53d2868a3713edbac8652f6eeea4614f8fce1442cb0
-generated: "2021-11-18T11:40:40.221678245+01:00"
+  version: 1.0.15
+digest: sha256:63e64efc6a9ec7db4964507a1f2ee93d8a18f6858a6688a608f825242c8d42ce
+generated: "2022-01-03T13:01:40.087105852+01:00"

--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.7
+version: 2.0.10
 
 dependencies:
   - name: nidhogg
-    version: 1.0.13
+    version: 1.0.15
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/nidhogg/values.yaml
+++ b/nidhogg/values.yaml
@@ -17,6 +17,7 @@ nidhogg:
       # ipRangeStop: 0.0.0.0
 
   installCNI: true
+  monitorNidhogg: true
 
   argo-cd-proxy-chart:
     argo-cd:

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.7
+version: 2.0.10
 
 dependencies:
   - name: lightvessel
-    version: "2.0.2"
+    version: "2.0.3"
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/yggdrasil/services/rook-ceph/config.yaml
+++ b/yggdrasil/services/rook-ceph/config.yaml
@@ -21,6 +21,6 @@ apps:
   - name: ntp
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.1.3
+      targetRevision: 0.1.4
       chart: ntp
       valuesFile: "ntp.yaml"


### PR DESCRIPTION
Added flag to decide if circular reference to monitor nidhogg should be enabled.
I have bumped nidhoggs version to fix the error of the overwritten values. The relevant pull-request in Nidhogg was [this](https://github.com/distributed-technologies/helm-charts/pull/218). 
In the commit that was made, a bump to ntp version was included, but it is not shown in the files changed, cause it has already been merged into the main branch.
Bumped lightvessel version to allow ingress to not be created