### PR TITLE
Fixed ceph flag indentation

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.11
+version: 2.0.12
 
 dependencies:
   - name: nidhogg

--- a/nidhogg/values.yaml
+++ b/nidhogg/values.yaml
@@ -3,6 +3,8 @@ nidhogg:
   yggdrasil:
     repoURL: "https://github.com/distributed-technologies/yggdrasil.git"
     targetRevision: "main"
+    # Enable the "enableCephAKS" to enable Ceph on AKS cluster. You can edit the number of OSDs in the values file for Ceph found in yggdrasil/services/rook-ceph/ceph/values.yaml
+    enableCephAKS: false
 
     # ingress:
       # Set either a subdomain or a path here
@@ -20,8 +22,6 @@ nidhogg:
   installCNI: true
   # Whether to enable the circular reference to allow nidhogg to monitor itself
   monitorNidhogg: true
-  # Enable the "enableCephAKS" to enable Ceph on AKS cluster. You can edit the number of OSDs in the values file for Ceph found in yggdrasil/services/rook-ceph/ceph/values.yaml
-  enableCephAKS: false
 
   argo-cd-proxy-chart:
     argo-cd:

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.11
+version: 2.0.12
 
 dependencies:
   - name: lightvessel


### PR DESCRIPTION
I have correctly indented the enableCephAKS value in nidhoggs values file.
This was wrongly indented under nidhogg instead of yggdrasil.