### PR TITLE
kafka: Remove application specific topics

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.13
+version: 2.0.14
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.13
+version: 2.0.14
 
 dependencies:
   - name: lightvessel

--- a/yggdrasil/services/kafka/kafka/kafka.yaml
+++ b/yggdrasil/services/kafka/kafka/kafka.yaml
@@ -102,18 +102,6 @@ prometheus-kafka-exporter:
   enabled: false
 
 topics:
-  - name: dlr-test
-    partitions: 1
-    replicas: 1
-  - name: dlr-test2
-    partitions: 1
-    replicas: 1
-  - name: dlr-scada-amps
-    partitions: 1
-    replicas: 1
-  - name: weather-forecast-raw
-    partitions: 1
-    replicas: 1
-  - name: vku-test
+  - name: test
     partitions: 1
     replicas: 1


### PR DESCRIPTION
The yggdrasil configuration on the main branch should not contain
application specific topics. We leave behind a generic `test` topic
as an example.