### PR TITLE
kafka: Remove resource quota from namespace

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.14
+version: 2.0.15
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.14
+version: 2.0.15
 
 dependencies:
   - name: lightvessel

--- a/yggdrasil/services/kafka/config.yaml
+++ b/yggdrasil/services/kafka/config.yaml
@@ -10,6 +10,6 @@ apps:
     replace: true
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.3.4
+      targetRevision: 1.1.2
       chart: kafka
       valuesFile: "kafka.yaml"

--- a/yggdrasil/services/kafka/kafka/kafka.yaml
+++ b/yggdrasil/services/kafka/kafka/kafka.yaml
@@ -10,43 +10,12 @@ cluster:
     {{- if .Values.storageClass }}
       class: {{ .Values.storageClass }}
     {{- end }}
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: "0m"
-      limits:
-        memory: 2Gi
-        cpu: "500m"
   zookeeper:
     storage:
       size: 5Gi
     {{- if .Values.storageClass }}
       class: {{ .Values.storageClass }}
     {{- end }}
-    resources:
-      requests:
-        memory: 256Mi
-        cpu: "0m"
-      limits:
-        memory: 1Gi
-        cpu: "500m"
-  entityOperator:
-    tlsSidecar:
-      resources:
-        requests:
-          memory: 64Mi
-          cpu: "0m"
-        limits:
-          memory: 128Mi
-          cpu: 200m
-  topicOperator:
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: "0m"
-        limits:
-          memory: 256Mi
-          cpu: "200m"
 
 cp-helm-charts:
   cp-kafka-connect:
@@ -64,13 +33,6 @@ cp-helm-charts:
     prometheus:
       jmx:
         enabled: false
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-      requests:
-        cpu: 0m
-        memory: 1Gi
 
   cp-schema-registry:
     enabled: true
@@ -81,22 +43,6 @@ cp-helm-charts:
     prometheus:
       jmx:
         enabled: false
-    resources:
-      limits:
-        cpu: 600m
-        memory: 1Gi
-      requests:
-        cpu: 0m
-        memory: 256Mi
-
-strimzi-kafka-operator:
-  resources:
-    requests:
-      memory: 200Mi
-      cpu: "0m"
-    limits:
-      memory: 400Mi
-      cpu: "300m"
 
 prometheus-kafka-exporter:
   enabled: false

--- a/yggdrasil/services/kafka/resource-quota.yaml
+++ b/yggdrasil/services/kafka/resource-quota.yaml
@@ -1,5 +1,0 @@
-hard:
-  requests.cpu: "4"
-  requests.memory: 8Gi
-  limits.cpu: "12"
-  limits.memory: 24Gi


### PR DESCRIPTION
We remove resource requirements from the values file as we currently do not know what "good" resource limits for the kafka components are. When we have resource quota in the namespace the pods will not deploy unless we set resource requirements.