### PR TITLE
Upgraded-services: bumped version for rook, ceph, traefik, grafana and nidhogg

### DIFF
--- a/nidhogg/Chart.lock
+++ b/nidhogg/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nidhogg
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 1.0.16
-digest: sha256:97e11f1fc17e1bfc895ed8d4caa1b5f2ef5770669bd35cfbd520e2383ff5919a
-generated: "2022-01-31T14:59:02.156972609+01:00"
+  version: 1.0.17
+digest: sha256:76f93166eca601193c6e4506414ebbc5e9b2c06ecfa30a4dafa266170f5a0d2e
+generated: "2022-02-21T15:23:28.261795228Z"

--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.16
+version: 2.0.17
 
 dependencies:
   - name: nidhogg
-    version: 1.0.16
+    version: 1.0.17
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.16
+version: 2.0.17
 
 dependencies:
   - name: lightvessel

--- a/yggdrasil/services/monitoring/config.yaml
+++ b/yggdrasil/services/monitoring/config.yaml
@@ -28,7 +28,7 @@ apps:
   - name: grafana
     source:
       repoURL: 'https://distributed-technologies.github.io/helm-charts/'
-      targetRevision: 0.1.8
+      targetRevision: 0.1.10
       chart: grafana
       valuesFile: "grafana.yaml"
     ingress:

--- a/yggdrasil/services/networking/config.yaml
+++ b/yggdrasil/services/networking/config.yaml
@@ -9,6 +9,6 @@ apps:
   - name: ingress
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.2.4
+      targetRevision: 0.2.5
       chart: traefik
       valuesFile: "ingress.yaml"

--- a/yggdrasil/services/rook-ceph/config.yaml
+++ b/yggdrasil/services/rook-ceph/config.yaml
@@ -9,13 +9,13 @@ apps:
   - name: rook
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.1.3
+      targetRevision: 0.1.4
       chart: rook
       valuesFile: "rook.yaml"
   - name: ceph
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.1.6
+      targetRevision: 0.1.7
       chart: rook-ceph-cluster
       valuesFile: "ceph.yaml"
   - name: ntp


### PR DESCRIPTION
I have bumped nidhogg to get the latest version of argocd
I have bumped rook, ceph, traefik and grafana to get the latest versions. 