### PR TITLE
yggdrasil: Bump NTP version

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.17
+version: 2.0.18
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.17
+version: 2.0.18
 
 dependencies:
   - name: lightvessel

--- a/yggdrasil/services/rook-ceph/config.yaml
+++ b/yggdrasil/services/rook-ceph/config.yaml
@@ -21,6 +21,6 @@ apps:
   - name: ntp
     source:
       repoURL: "https://distributed-technologies.github.io/helm-charts/"
-      targetRevision: 0.1.5
+      targetRevision: 0.1.6
       chart: ntp
       valuesFile: "ntp.yaml"


### PR DESCRIPTION
The chart version wasn't bumped correctly in [2], so the following
commit to the chart wasn't included:
1528025 ("ntp: Fix wrong container image version")[1]

Fixes: 1ff96fd ("yggdrasil: Bump NTP version")[2]

[1] https://github.com/distributed-technologies/helm-charts/pull/257
[2] https://github.com/distributed-technologies/yggdrasil/pull/67