### PR TITLE
yggdrasil: Add kube-state-metrics to our monitoring stack

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.19
+version: 2.0.20
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.19
+version: 2.0.20
 
 dependencies:
   - name: lightvessel
@@ -10,4 +10,5 @@ dependencies:
 
 annotations:
   changeLog: |
+    [2.0.20]: Added kube-state-metrics.
     [2.0.19]: Added Cortex and Tempo with configurations.

--- a/yggdrasil/services/monitoring/config.yaml
+++ b/yggdrasil/services/monitoring/config.yaml
@@ -43,3 +43,9 @@ apps:
       targetRevision: 0.1.1
       chart: tempo-distributed
       valuesFile: "tempo.yaml"
+  - name: kube-state-metrics
+    source:
+      repoURL: 'https://distributed-technologies.github.io/helm-charts/'
+      targetRevision: 0.1.0
+      chart: kube-state-metrics
+      valuesFile: "kube-state-metrics.yaml"

--- a/yggdrasil/services/monitoring/kube-state-metrics/kube-state-metrics.yaml
+++ b/yggdrasil/services/monitoring/kube-state-metrics/kube-state-metrics.yaml
@@ -1,0 +1,5 @@
+kube-state-metrics:
+  prometheus:
+    monitor:
+      additionalLabels:
+        instance: primary

--- a/yggdrasil/values.yaml
+++ b/yggdrasil/values.yaml
@@ -19,6 +19,7 @@ applications:
   influxdb: false
   ingress: false
   kafka: false
+  kube-state-metrics: false
   loadbalancer: false
   loki: false
   nifi: false


### PR DESCRIPTION
"kube-state-metrics (KSM) is a simple service that listens to the
Kubernetes API server and generates metrics about the state of the
objects. [...] It is not focused on the health of the individual
Kubernetes components, but rather on the health of the various objects
inside, such as deployments, nodes and pods."[1]

Chart added in [2].

[1] https://github.com/kubernetes/kube-state-metrics
[2] https://github.com/distributed-technologies/helm-charts/pull/253

---

https://github.com/distributed-technologies/helm-charts/pull/253 must go in first.