### PR TITLE
yggdrasil: Add service for external-dns

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.19
+version: 2.0.20
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.19
+version: 2.0.20
 
 dependencies:
   - name: lightvessel

--- a/yggdrasil/services/networking/config.yaml
+++ b/yggdrasil/services/networking/config.yaml
@@ -12,3 +12,9 @@ apps:
       targetRevision: 0.2.5
       chart: traefik
       valuesFile: "ingress.yaml"
+  - name: external-dns
+    source:
+      repoURL: 'https://distributed-technologies.github.io/helm-charts/'
+      targetRevision: 0.1.0
+      chart: external-dns
+      valuesFile: "external-dns.yaml"

--- a/yggdrasil/services/networking/external-dns/external-dns.yaml
+++ b/yggdrasil/services/networking/external-dns/external-dns.yaml
@@ -1,0 +1,10 @@
+external-dns:
+  # Environment variables for the external-dns container, this supports the full EnvVar API including secrets and configmaps.
+  env: {{- (index .Values "external-dns").env | toYaml | nindent 4 }}
+  # How DNS records are synchronized between sources and providers, available values are: sync, upsert-only.
+  policy: {{ (index .Values "external-dns").policy }}
+  # Limit possible target zones by domain suffixes.
+  domainFilters: {{ (index .Values "external-dns").domainFilters }}
+  # DNS provider where the DNS records will be created, for the available providers and how to configure them see the README.
+  # https://github.com/kubernetes-sigs/external-dns#deploying-to-a-cluster
+  provider: {{ (index .Values "external-dns").provider }}

--- a/yggdrasil/values.yaml
+++ b/yggdrasil/values.yaml
@@ -13,6 +13,7 @@ applications:
   cert-manager: false
   cortex: false
   example-guestbook: false
+  external-dns: false
   grafana: false
   grafana-agent: false
   harbor: false


### PR DESCRIPTION
"ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
DNS providers."[1]

We need this to ease access to development clusters, by synchronizing
Services and Ingresses into a internal DNS zone. Proxy chart PR[2].

The service can be configured from yggdrasil, which implies it can also
be configured from nidhogg. This is done so mukube-configurator can
configure it (PR[3]), as the DNS zone is provisioned together with the
cluster, so it is easier to also set the zone for external-dns at the
same time.

[1] https://github.com/kubernetes-sigs/external-dns
[2] https://github.com/distributed-technologies/helm-charts/pull/264
[3] https://github.com/distributed-technologies/mukube-configurator/pull/49