### PR TITLE
Grafana agent replacement

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.21
+version: 2.0.22
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.21
+version: 2.0.22
 
 dependencies:
   - name: lightvessel
@@ -10,5 +10,6 @@ dependencies:
 
 annotations:
   changeLog: |
+    [2.0.22]: Remove Grafana-agents & add prometheus & promtail
     [2.0.20]: Added exporters chart with configurations.
     [2.0.19]: Added Cortex and Tempo with configurations.

--- a/yggdrasil/services/monitoring/config.yaml
+++ b/yggdrasil/services/monitoring/config.yaml
@@ -9,7 +9,7 @@ apps:
   - name: cortex
     source:
       repoURL: 'https://distributed-technologies.github.io/helm-charts/'
-      targetRevision: 0.1.2
+      targetRevision: 0.1.3
       chart: cortex
       valuesFile: "cortex.yaml"
   - name: grafana
@@ -25,16 +25,22 @@ apps:
         serviceName: grafana
         annotation:
           traefik.ingress.kubernetes.io/router.entrypoints: web
-  - name: grafana-agent
+  - name: prometheus
     source:
       repoURL: 'https://distributed-technologies.github.io/helm-charts/'
-      targetRevision: 0.1.1
-      chart: grafana-agent
-      valuesFile: "grafana-agent.yaml"
+      targetRevision: 0.1.4
+      chart: prometheus
+      valuesFile: "prometheus.yaml"
+  - name: promtail
+    source:
+      repoURL: 'https://distributed-technologies.github.io/helm-charts/'
+      targetRevision: 0.1.0
+      chart: promtail
+      valuesFile: "promtail.yaml"
   - name: loki
     source:
       repoURL: 'https://distributed-technologies.github.io/helm-charts/'
-      targetRevision: 1.0.0
+      targetRevision: 1.0.1
       chart: loki
       valuesFile: "loki.yaml"
   - name: tempo

--- a/yggdrasil/services/monitoring/grafana-agent/grafana-agent.yaml
+++ b/yggdrasil/services/monitoring/grafana-agent/grafana-agent.yaml
@@ -1,4 +1,0 @@
-logs:
-  remote-write-url: http://loki-loki-distributed-distributor:3100/loki/api/v1/push
-metrics:
-  remote-write-url: http://cortex-distributor:8080/api/v1/push

--- a/yggdrasil/services/monitoring/grafana/grafana.yaml
+++ b/yggdrasil/services/monitoring/grafana/grafana.yaml
@@ -57,6 +57,10 @@ grafana:
   adminUser: admin
   adminPassword: password
 
+  grafana.ini:
+    feature_toggles:
+      enable: tempoSearch tempoBackendSearch
+
   sidecar:
   {{- if .Values.registry }}
     image:

--- a/yggdrasil/services/monitoring/prometheus/prometheus.yaml
+++ b/yggdrasil/services/monitoring/prometheus/prometheus.yaml
@@ -1,0 +1,2 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+# kube-prometheus-stack:

--- a/yggdrasil/services/monitoring/promtail/promtail.yaml
+++ b/yggdrasil/services/monitoring/promtail/promtail.yaml
@@ -1,0 +1,2 @@
+# https://github.com/grafana/helm-charts/blob/main/charts/promtail/values.yaml
+# promtail:

--- a/yggdrasil/values.yaml
+++ b/yggdrasil/values.yaml
@@ -15,7 +15,6 @@ applications:
   example-guestbook: false
   external-dns: false
   grafana: false
-  grafana-agent: false
   harbor: false
   influxdb: false
   ingress: false
@@ -24,6 +23,8 @@ applications:
   loki: false
   nifi: false
   ntp: false
+  prometheus: false
+  promtail: false
   rook: false
   tempo: false
   vault: false


### PR DESCRIPTION
We decided to remove Grafana agents, since we felt like they we're too imature right now, so this commit removes them from Yggdrasil and reintroduces Prometheus as Metrics scraper and Promtail as log scraper.

This PR is related to [helm-charts#278](https://github.com/distributed-technologies/helm-charts/pull/278)

Changes: 
* Remove Grafana-agents
* Add Prometheus and Promtail
* Updated Loki and Cortex versions
* Addition to Grafana values that was missed in the introduction of Tempo