### PR TITLE
Add exporters chart

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 2.0.20
+version: 2.0.21
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 2.0.20
+version: 2.0.21
 
 dependencies:
   - name: lightvessel
@@ -10,4 +10,5 @@ dependencies:
 
 annotations:
   changeLog: |
+    [2.0.20]: Added exporters chart with configurations.
     [2.0.19]: Added Cortex and Tempo with configurations.

--- a/yggdrasil/services/monitoring/config.yaml
+++ b/yggdrasil/services/monitoring/config.yaml
@@ -43,3 +43,9 @@ apps:
       targetRevision: 0.1.1
       chart: tempo-distributed
       valuesFile: "tempo.yaml"
+  - name: exporters
+    source:
+      repoURL: 'https://distributed-technologies.github.io/helm-charts/'
+      targetRevision: 0.1.0
+      chart: exporters
+      valuesFile: "exporters.yaml"

--- a/yggdrasil/services/monitoring/exporters/exporters.yaml
+++ b/yggdrasil/services/monitoring/exporters/exporters.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.applications.prometheus }}
+kube-state-metrics:
+  enabled: true
+  prometheus:
+    monitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+prometheus-node-exporter:
+  enabled: true
+  prometheus:
+    monitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  {{- if .Values.applications.kafka }}
+prometheus-kafka-exporter:
+  enabled: true
+  prometheus:
+    enabled: true
+    namespace: ""
+    additionalLabels:
+      instance: primary
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Add logic to only enable service monitors when prometheus is installed
Add logic to only enable kafka exporter when kafka and prometheus is installed

This PR enabled the functionality from distributed-technologies/helm-charts/pull/280