### PR TITLE
Resource-quotas: Add RQ for ceph, monitoring and networking

### DIFF
--- a/nidhogg/Chart.yaml
+++ b/nidhogg/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for nidhogg values and dependencies
 type: application
-version: 3.0.0
+version: 3.0.1
 
 dependencies:
   - name: nidhogg

--- a/yggdrasil/Chart.yaml
+++ b/yggdrasil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yggdrasil
 description: A Helm chart for for deploying an entire repo.
-version: 3.0.0
+version: 3.0.1
 
 dependencies:
   - name: lightvessel
@@ -10,6 +10,7 @@ dependencies:
 
 annotations:
   changeLog: |
+    [3.0.1]: Add resource quotas for service-layer
     [3.0.0]: Remove all unused services
     [2.0.23]: Bump rook to use the chart's image version
     [2.0.22]: Remove Grafana-agents & add prometheus & promtail

--- a/yggdrasil/services/monitoring/resource-quota.yaml
+++ b/yggdrasil/services/monitoring/resource-quota.yaml
@@ -1,0 +1,6 @@
+hard:
+  requests.storage: 2Ti
+  requests.cpu: "8"
+  requests.memory: 32Gi
+  limits.cpu: "16"
+  limits.memory: 64Gi

--- a/yggdrasil/services/networking/resource-quota.yaml
+++ b/yggdrasil/services/networking/resource-quota.yaml
@@ -1,0 +1,6 @@
+hard:
+  requests.storage: 200Gi
+  requests.cpu: "2"
+  requests.memory: 8Gi
+  limits.cpu: "4"
+  limits.memory: 16Gi

--- a/yggdrasil/services/rook-ceph/resource-quota.yaml
+++ b/yggdrasil/services/rook-ceph/resource-quota.yaml
@@ -1,0 +1,6 @@
+hard:
+  requests.storage: 10Ti
+  requests.cpu: "4"
+  requests.memory: 16Gi
+  limits.cpu: "8"
+  limits.memory: 32Gi

--- a/yggdrasil/services/rook-ceph/resource-quota.yaml
+++ b/yggdrasil/services/rook-ceph/resource-quota.yaml
@@ -1,5 +1,5 @@
 hard:
-  requests.storage: 10Ti
+  requests.storage: 0Gi
   requests.cpu: "4"
   requests.memory: 16Gi
   limits.cpu: "8"


### PR DESCRIPTION
I have tried estimating the values for resource quotas. These are more or less a guess, since we do not know the resources that are needed in production. I have tried looking up resource use for each individual service we are using, but most often they just write "give this service enough". 

@klausenbusk you have written that we need to configure [this](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/). Will that need to be done here?