### PR TITLE
Network-policy for Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Deploy the platform for development on Azure
 You can create a development environment that uses Yggdrasil. This development environment will consist of 3 nodes and 3 storage nodes that together form an AKS cluster.
-When clicking the deployment button, you will be redirected to Azure. Here, you will have to configure the deployment the way you would like. Most settings are preconfigured with values that are standard. However, you have to fill in the resource group you would like for the resource to be created in. 
+When clicking the deployment button, you will be redirected to Azure. Here, you will have to configure the deployment the way you would like. Most settings are preconfigured with values that are standard. However, you have to fill in the resource group you would like for the resource to be created in.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fdistributed-technologies%2Fyggdrasil%2Fmain%2Farm-templates%2Ftemplate.json)
 
-When the resource creation finishes, you can choose to either use the shell in Azure found in the top right corner where the terminal icon is, or if you would like to authenticate to the cluster from your local development machine. We recommend authenticating from your own machine. A prerequisite to do this is the Azure CLI. You can find information on how to install that [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli). When you have installed the Azure CLI, you can use the following command to authenticate to the AKS cluster: 
+When the resource creation finishes, you can choose to either use the shell in Azure found in the top right corner where the terminal icon is, or if you would like to authenticate to the cluster from your local development machine. We recommend authenticating from your own machine. A prerequisite to do this is the Azure CLI. You can find information on how to install that [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli). When you have installed the Azure CLI, you can use the following command to authenticate to the AKS cluster:
 ```
 az aks get-credentials --resource-group <YOUR-RESOURCE-GROUP-NAME> --name <YOUR-RESOURCE-NAME>
 ```
@@ -18,7 +18,7 @@ kubectl get nodes
 You now have access to your new Kubernetes development environment. The next thing we need to do is deploy Yggdrasil onto the cluster.
 To install Yggdrasil on the AKS cluster, you need to have Helm installed. A guide to install helm can be found [here](https://helm.sh/docs/intro/install/).
 
-Once Helm has been installed, you need to clone the Yggdrasil repository, cd into it and run a helm dependency update. 
+Once Helm has been installed, you need to clone the Yggdrasil repository, cd into it and run a helm dependency update.
 
 ```
 git clone https://github.com/distributed-technologies/yggdrasil.git
@@ -30,27 +30,27 @@ Yggdrasil uses a GitOps architecture and therefore needs to have an environment 
 
 To set any cluster configurations, you should edit the nidhogg/values.yaml file. Once you are satisfied with the configurations of the cluster, edit the yggdrasil/values.yaml file and enable the services that you would like to enable on the cluster. You should change the `cni.enabled` flag to "false" and change the enableCephAKS to "true". The value nidhogg.yggdrasil.repoURL should be set to the repository URL of your new github repository. You should also configure the nidhogg.yggdrasil.targetRevision to be the branch you are using in your repository.
 
-For development purposes, the admin password during development for argoCD has been set in the Nidhogg values file. However, since you might expose argoCD with a public IP through a loadbalancer, it is recommended that you remove this value and let argoCD create an admin password and store it in a secret. Delete the value nidhogg.argo-cd-proxy-chart.argo-cd.configs.secret. In order to access the argoCD dashboard through a public IP, you need to change the service type value nidhogg.argo-cd-proxy-chart.argo-cd.server.service.type to LoadBalancer. 
+For development purposes, the admin password during development for argoCD has been set in the Nidhogg values file. However, since you might expose argoCD with a public IP through a loadbalancer, it is recommended that you remove this value and let argoCD create an admin password and store it in a secret. Delete the value nidhogg.argo-cd-proxy-chart.argo-cd.configs.secret. In order to access the argoCD dashboard through a public IP, you need to change the service type value nidhogg.argo-cd-proxy-chart.argo-cd.server.service.type to LoadBalancer.
 
-You also need to set the storage class that Yggdrasils applications and services should use. This is done in the yggdrasil/values.yaml file. If you choose to use the Ceph filesystem for storage, this value should be "ceph-filesystem". If you do not want to enable Ceph on AKS, you should put "default". 
+You also need to set the storage class that Yggdrasils applications and services should use. This is done in the yggdrasil/values.yaml file. If you choose to use the Ceph filesystem for storage, this value should be "ceph-filesystem". If you do not want to enable Ceph on AKS, you should put "default".
 
 ```
 storageClass: <your-storageclass-here>
 ```
 
-You are now ready to install Yggdrasil on the cluster by running this command: 
+You are now ready to install Yggdrasil on the cluster by running this command:
 
 ```
 helm install --create-namespace -n yggdrasil nidhogg nidhogg/
 ```
 
-The platform will now bootstrap onto the AKS cluster and you can follow this process by executing the command: 
+The platform will now bootstrap onto the AKS cluster and you can follow this process by executing the command:
 
 ```
 watch kubectl get pods -A
 ```
 
-Once the pods are all in a Running state, it is possible for you to gain access to the ArgoCD dashboard. In order to do so, you will need to change the service to a type Loadbalancer and you will need to extract the password from the secret inside the cluster. 
+Once the pods are all in a Running state, it is possible for you to gain access to the ArgoCD dashboard. In order to do so, you will need to change the service to a type Loadbalancer and you will need to extract the password from the secret inside the cluster.
 
 The default user is "admin". To extract the password(if you have unset it in the Nidhogg values file), run:
 
@@ -58,20 +58,23 @@ The default user is "admin". To extract the password(if you have unset it in the
 kubectl -n yggdrasil get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
 ```
 
-Now that you have the password, you need to get the public IP of the loadbalancer argoCD has created. To find the public IP of the loadbalancer, run: 
+Now that you have the password, you need to get the public IP of the loadbalancer argoCD has created. To find the public IP of the loadbalancer, run:
 
 ```
 kubectl get svc -n yggdrasil
 ```
-Here, you should see the service called nidhogg-argocd-server and be able to see a public IP that you can access from your browser and login with the username and password. 
+Here, you should see the service called nidhogg-argocd-server and be able to see a public IP that you can access from your browser and login with the username and password.
+
+# Network-policies
+The current status of the network policies can be found on the [network-policies.md](docs/Network-policies.md)
 
 # Changes in 2.0.0
-In this version we have done the following changes: 
-- Removed project definition from config.yaml and put it into its own file. This has been done because we are seeing a need to use all the configurations an argo project gives us, not just the limited subset that we had first configured. 
+In this version we have done the following changes:
+- Removed project definition from config.yaml and put it into its own file. This has been done because we are seeing a need to use all the configurations an argo project gives us, not just the limited subset that we had first configured.
 - Added networkPolicy and resourceQuota definitions for namespaces
 
 ### Upgrading from 1.x.x to 2.0.0
-In order to upgrade from the previous version, you need to delete the project definition from your config.yaml in all your namespaces. These project definitions should then be added as a file on the same path as the config.yaml but be called project.yaml instead. This file can only contain the spec part of the project manifest, which can be found [here](https://argo-cd.readthedocs.io/en/latest/operator-manual/project.yaml): 
+In order to upgrade from the previous version, you need to delete the project definition from your config.yaml in all your namespaces. These project definitions should then be added as a file on the same path as the config.yaml but be called project.yaml instead. This file can only contain the spec part of the project manifest, which can be found [here](https://argo-cd.readthedocs.io/en/latest/operator-manual/project.yaml):
 
 # Yggdrasil
 This is the repository for the cluster environment. It contains two Helm charts called Nidhogg and Yggdrasil.
@@ -151,7 +154,7 @@ description: <description>
 # Optional
 # Global labels - these will be set on all apps in the config
 # the label 'app: <appName>' is set by default
-namespaceLabels: 
+namespaceLabels:
   label1: label1
 labels:
   label1: label1
@@ -200,8 +203,8 @@ project:
 ```
 
 # Defining a project
-Next to the config.yaml file, every namespace should have a project definition. This is important because projects isolate namespaces and services from interfering with each other. 
-A project definition could look like this: 
+Next to the config.yaml file, every namespace should have a project definition. This is important because projects isolate namespaces and services from interfering with each other.
+A project definition could look like this:
 ``` yaml
 description: <name> Argo Project
 sourceRepos:
@@ -213,27 +216,27 @@ clusterResourceWhitelist:
 - group: '*'
   kind: 'Deployment'
 ```
-More options to configure the project can be found [here](https://argo-cd.readthedocs.io/en/latest/operator-manual/project.yaml). 
+More options to configure the project can be found [here](https://argo-cd.readthedocs.io/en/latest/operator-manual/project.yaml).
 
-Contributors should also define a networkPolicy and a resourceQuota for your namespace. These files should be placed next to the config.yaml and be called network-policy.yaml and resource-quota.yaml. It is only possible to include the `spec` part of these resources. A typical network-policy could look like this: 
+Contributors should also define a networkPolicy and a resourceQuota for your namespace. These files should be placed next to the config.yaml and be called network-policy.yaml and resource-quota.yaml. It is only possible to include the `spec` part of these resources. A typical network-policy could look like this:
 ``` yaml
 podSelector: {}
 policyTypes:
 - Ingress
 - Egress
 ingress:
-- from: 
-  - namespaceSelector: 
-      matchLabels: 
+- from:
+  - namespaceSelector:
+      matchLabels:
         space: service
 egress:
-- to: 
+- to:
   - namespaceSelector:
-      matchLabels: 
+      matchLabels:
         space: service
 ```
 
-A typical resource-quota could look like this: 
+A typical resource-quota could look like this:
 ``` yaml
 hard:
   requests.cpu: "8"
@@ -242,7 +245,7 @@ hard:
   limits.memory: 40Gi
 ```
 
-Example of these can also be found throughout the yggdrasil/services folder. 
+Example of these can also be found throughout the yggdrasil/services folder.
 
 A PR will then need to be approved by the cluster development team, before it is merged into Yggdrasil. When this is merged, ArgoCD will automatically deploy the application onto the cluster.
 When the deployment is done, ArgoCD will poll the environment repository every 3 minutes, to check for changes to the application.

--- a/docs/Network-policies.md
+++ b/docs/Network-policies.md
@@ -1,0 +1,31 @@
+# Network policies
+
+The current state of network policies.
+
+The objective is to ensure that network policies are pressent on every namespace, and if they should not be present, this document will then describe why.
+
+To the best of our abilities we will try and describe, high level, what applications we have in the service layer, and what NS we expect it to be talking to
+<!--
+By default, a pod is non-isolated for egress; all outbound connections are allowed.
+By default, a pod is non-isolated for ingress; all inbound connections are allowed.
+-->
+
+A place to get some inspiration:
+https://github.com/ahmetb/kubernetes-network-policy-recipes
+
+## Monitoring
+Monitoring currently only have two apps that needs to either talk, out of / in to, the monitoring namespace
+
+```mermaid
+  flowchart LR
+    p(Prometheus) -- Egress --> metricsApp(Every NS that has an app that exposes metrics)
+
+    tracingApp(Any NS that has an app that wants to deliver traces to tempo) -- Ingress --> t(Tempo)
+```
+Prometheus needs to be able to establish connectins (egress) to most apps outside it's own NS.
+Tempo needs to allow connections (ingress) from most apps outside it's own NS.
+
+The conclusion is that the monitoring namespaces should **allow ingress from all namespaces**, and **allow egress to all namespaces**
+
+The current implimentation of the network policy for the monitoring namespace. <br>
+[monitoring-network-policy.yaml](/yggdrasil/services/monitoring/network-policy.yaml)

--- a/yggdrasil/services/monitoring/network-policy.yaml
+++ b/yggdrasil/services/monitoring/network-policy.yaml
@@ -1,0 +1,11 @@
+policyTypes:
+  - Ingress
+  - Egress
+podSelector:
+  matchLable: {}
+ingress:
+  - from:
+    - namespaceSelector: {}
+egress:
+  - to:
+    - namespaceSelector: {}


### PR DESCRIPTION
* Add ref to `network-policies.md` to `README.md`
* Add `network-policy.yaml` to monitoring folder

The plan is for `network-policies.md` to document the current network-policy setup,
and contain the reason for the propossed settings.